### PR TITLE
Heroku dyno status monitors Bounty #56

### DIFF
--- a/cram/checks/heroku-dyno-not-idle-single/__init__.py
+++ b/cram/checks/heroku-dyno-not-idle-single/__init__.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+######################################################################
+## Cloud Routes Availability Manager: heroku-dyno-not-idle-single module
+## ------------------------------------------------------------------
+## This module will query Heroku's api and check for a single dyno's status
+## This will return true if no errors or false if there are errors
+## ------------------------------------------------------------------
+## Author: Benjamin J. Cane - madflojo@cloudrout.es
+######################################################################
+
+import requests
+import json
+import base64
+import syslog
+
+def check(data):
+  """ Checks Heroku's api status for a specified dyno """
+  basekey = base64.b64encode(":" + data['data']['apikey'])
+  headers = {
+    "Accept" : "application/vnd.heroku+json; version=3",
+    "Authorization" : basekey
+  }
+  timeout = 5.00
+  url = "https://api.heroku.com/apps/" + data['data']['appname'] + "/dynos/" + data['data']['dynoname']
+  try:
+    result = requests.get(url, timeout=timeout, headers=headers, verify=True)
+  except:
+    return None
+  line = "heroku-dyno-status: Got response from heroku for monitor - %s" % (result.text)
+  syslog.syslog(syslog.LOG_DEBUG, line)
+  retdata = json.loads(result.text)
+  if "state" in retdata:
+    if retdata['state'] == "idle":
+      return False
+    else:
+      return True
+  else:
+    return None

--- a/cram/checks/heroku-dyno-not-idle/__init__.py
+++ b/cram/checks/heroku-dyno-not-idle/__init__.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+######################################################################
+## Cloud Routes Availability Manager: heroku-dyno-status module
+## ------------------------------------------------------------------
+## This module will query Heroku's api and check for a single dyno's status
+## This will return true if no errors or false if there are errors
+## ------------------------------------------------------------------
+## Author: Benjamin J. Cane - madflojo@cloudrout.es
+######################################################################
+
+import requests
+import json
+import base64
+import syslog
+
+def check(data):
+  """ Checks Heroku's api status for dyno status"""
+  basekey = base64.b64encode(":" + data['data']['apikey'])
+  headers = {
+    "Accept" : "application/vnd.heroku+json; version=3",
+    "Authorization" : basekey
+  }
+  timeout = 5.00
+  url = "https://api.heroku.com/apps/" + data['data']['appname'] + "/dynos"
+  try:
+    result = requests.get(url, timeout=timeout, headers=headers, verify=True)
+  except:
+    return None
+  line = "heroku-dyno-status: Got response from heroku for monitor - %s" % (result.text)
+  syslog.syslog(syslog.LOG_DEBUG, line)
+  retdata = json.loads(result.text)
+  failed = 0
+  if result.status_code >= 200 and result.status_code <= 299:
+    for dyno in retdata:
+      if dyno['state'] == "idle":
+       failed = failed + 1
+  else:
+    return None
+  
+  if failed == 0:
+    return True
+  else:
+    return False

--- a/cram/checks/heroku-dyno-status-single/__init__.py
+++ b/cram/checks/heroku-dyno-status-single/__init__.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+######################################################################
+## Cloud Routes Availability Manager: heroku-dyno-status-single module
+## ------------------------------------------------------------------
+## This module will query Heroku's api and check for a single dyno's status
+## This will return true if no errors or false if there are errors
+## ------------------------------------------------------------------
+## Author: Benjamin J. Cane - madflojo@cloudrout.es
+######################################################################
+
+import requests
+import json
+import base64
+import syslog
+
+def check(data):
+  """ Checks Heroku's api status for a specified dyno """
+  basekey = base64.b64encode(":" + data['data']['apikey'])
+  headers = {
+    "Accept" : "application/vnd.heroku+json; version=3",
+    "Authorization" : basekey
+  }
+  timeout = 5.00
+  url = "https://api.heroku.com/apps/" + data['data']['appname'] + "/dynos/" + data['data']['dynoname']
+  try:
+    result = requests.get(url, timeout=timeout, headers=headers, verify=True)
+  except:
+    return None
+  line = "heroku-dyno-status-single: Got response from heroku for monitor - %s" % (result.text)
+  syslog.syslog(syslog.LOG_DEBUG, line)
+  retdata = json.loads(result.text)
+  if "state" in retdata:
+    if retdata['state'] == "up" or retdata['state'] == "idle":
+      return True
+    else:
+      return False
+  else:
+    return None

--- a/cram/checks/heroku-dyno-status/__init__.py
+++ b/cram/checks/heroku-dyno-status/__init__.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+######################################################################
+## Cloud Routes Availability Manager: heroku-dyno-status module
+## ------------------------------------------------------------------
+## This module will query Heroku's api and check for a single dyno's status
+## This will return true if no errors or false if there are errors
+## ------------------------------------------------------------------
+## Author: Benjamin J. Cane - madflojo@cloudrout.es
+######################################################################
+
+import requests
+import json
+import base64
+import syslog
+
+def check(data):
+  """ Checks Heroku's api status for dyno status"""
+  basekey = base64.b64encode(":" + data['data']['apikey'])
+  headers = {
+    "Accept" : "application/vnd.heroku+json; version=3",
+    "Authorization" : basekey
+  }
+  timeout = 5.00
+  url = "https://api.heroku.com/apps/" + data['data']['appname'] + "/dynos"
+  try:
+    result = requests.get(url, timeout=timeout, headers=headers, verify=True)
+  except:
+    return None
+  line = "heroku-dyno-status: Got response from heroku for monitor - %s" % (result.text)
+  syslog.syslog(syslog.LOG_DEBUG, line)
+  retdata = json.loads(result.text)
+  failed = 0
+  if result.status_code >= 200 and result.status_code <= 299:
+    for dyno in retdata:
+      if dyno['state'] != "up" and dyno['state'] != "idle":
+       failed = failed + 1
+  else:
+    return None
+  
+  if failed == 0:
+    return True
+  else:
+    return False

--- a/cram/worker.py
+++ b/cram/worker.py
@@ -104,7 +104,7 @@ while True:
   # Load health check module and run it
   monitor = __import__("checks." + jdata['ctype'], globals(), locals(), ['check'], -1)
   result = monitor.check(jdata)
-  if result:
+  if result == True:
     # Log it
     stat = "[%s] Healthy Checks" % config['envname']
     stathat.ez_count(config['stathat_ez_key'], stat, 1)
@@ -114,6 +114,10 @@ while True:
                         'method': 'automatic' }
     # Send success to sink
     ztext = json.dumps(jdata)
+  elif result == None:
+    line = "Health check %s was unable to execute" % (jdata['cid'])
+    syslog.syslog(syslog.LOG_ERR, line)
+    ztext = None
   else:
     # Log it
     stat = "[%s] Failed Checks" % config['envname']
@@ -127,8 +131,9 @@ while True:
     ztext = json.dumps(jdata)
 
   # Send data to sink and log it
-  zsend.send(ztext)
-  stat = "[%s] Checks sent to sink from workers" % config['envname']
-  stathat.ez_count(config['stathat_ez_key'], stat, 1)
-  line = "Health check %s sent to sink" % jdata['cid']
-  syslog.syslog(syslog.LOG_INFO, line)
+  if ztext is not None:
+    zsend.send(ztext)
+    stat = "[%s] Checks sent to sink from workers" % config['envname']
+    stathat.ez_count(config['stathat_ez_key'], stat, 1)
+    line = "Health check %s sent to sink" % jdata['cid']
+    syslog.syslog(syslog.LOG_INFO, line)

--- a/crweb/monitorforms/heroku-dyno-not-idle-single/__init__.py
+++ b/crweb/monitorforms/heroku-dyno-not-idle-single/__init__.py
@@ -1,0 +1,19 @@
+######################################################################
+## Cloud Routes Web Application
+## -------------------------------------------------------------------
+## Health Check - Forms Class
+######################################################################
+
+from wtforms import Form
+from wtforms import TextField
+from wtforms.validators import DataRequired
+from ..datacenter import DatacenterCheckForm
+
+class CheckForm(DatacenterCheckForm):
+  ''' Creates a wtforms form object for monitors '''
+  apikey = TextField("API Key", validators=[DataRequired(message='API Key is a required field')])
+  appname = TextField("Application Name", validators=[DataRequired(message='Application Name is a required field')])
+  dynoname = TextField("Dyno Name", validators=[DataRequired(message='Dyno Name is a required field')])
+
+if __name__ == '__main__':
+  pass

--- a/crweb/monitorforms/heroku-dyno-not-idle/__init__.py
+++ b/crweb/monitorforms/heroku-dyno-not-idle/__init__.py
@@ -1,0 +1,18 @@
+######################################################################
+## Cloud Routes Web Application
+## -------------------------------------------------------------------
+## Health Check - Forms Class
+######################################################################
+
+from wtforms import Form
+from wtforms import TextField
+from wtforms.validators import DataRequired
+from ..datacenter import DatacenterCheckForm
+
+class CheckForm(DatacenterCheckForm):
+  ''' Creates a wtforms form object for monitors '''
+  apikey = TextField("API Key", validators=[DataRequired(message='API Key is a required field')])
+  appname = TextField("Application Name", validators=[DataRequired(message='Application Name is a required field')])
+
+if __name__ == '__main__':
+  pass

--- a/crweb/monitorforms/heroku-dyno-status-single/__init__.py
+++ b/crweb/monitorforms/heroku-dyno-status-single/__init__.py
@@ -1,0 +1,19 @@
+######################################################################
+## Cloud Routes Web Application
+## -------------------------------------------------------------------
+## Health Check - Forms Class
+######################################################################
+
+from wtforms import Form
+from wtforms import TextField
+from wtforms.validators import DataRequired
+from ..datacenter import DatacenterCheckForm
+
+class CheckForm(DatacenterCheckForm):
+  ''' Creates a wtforms form object for monitors '''
+  apikey = TextField("API Key", validators=[DataRequired(message='API Key is a required field')])
+  appname = TextField("Application Name", validators=[DataRequired(message='Application Name is a required field')])
+  dynoname = TextField("Dyno Name", validators=[DataRequired(message='Dyno Name is a required field')])
+
+if __name__ == '__main__':
+  pass

--- a/crweb/monitorforms/heroku-dyno-status/__init__.py
+++ b/crweb/monitorforms/heroku-dyno-status/__init__.py
@@ -1,0 +1,18 @@
+######################################################################
+## Cloud Routes Web Application
+## -------------------------------------------------------------------
+## Health Check - Forms Class
+######################################################################
+
+from wtforms import Form
+from wtforms import TextField
+from wtforms.validators import DataRequired
+from ..datacenter import DatacenterCheckForm
+
+class CheckForm(DatacenterCheckForm):
+  ''' Creates a wtforms form object for monitors '''
+  apikey = TextField("API Key", validators=[DataRequired(message='API Key is a required field')])
+  appname = TextField("Application Name", validators=[DataRequired(message='Application Name is a required field')])
+
+if __name__ == '__main__':
+  pass

--- a/static/templates/monitors.html
+++ b/static/templates/monitors.html
@@ -33,6 +33,20 @@
             <p>This monitor will perform a single ICMP ping request and validate the host responds.</p>
           </div>
           <!-- End Health Check 8 lines -->
+          <!-- Start Health Check -->
+          <div class="well">
+            <center><img src="/static/img/buttons/heroku-150.png" class="img-responsive"></center>
+            <h4>Heroku <small>Dyno Status (Single)</small></h4>
+            <p>This monitor will watch the status of a specific Dyno.</p>
+          </div>
+          <!-- End Health Check 8 lines -->
+          <!-- Start Health Check -->
+          <div class="well">
+            <center><img src="/static/img/buttons/heroku-150.png" class="img-responsive"></center>
+            <h4>Heroku <small>Dyno Status</small></h4>
+            <p>This monitor will watch the status of all Dynos.</p>
+          </div>
+          <!-- End Health Check 8 lines -->
         </div>
         <div class="col-md-6">
           <!-- Start Health Check -->
@@ -61,6 +75,20 @@
             <center><img src="/static/img/buttons/logentries-150.png" class="img-responsive"></center>
             <h4>Logentries Alerts <small>Webhooks</small></h4>
             <p>Use Logentries Alerts and Tags to trigger CloudRoutes reactions.</p>
+          </div>
+          <!-- End Health Check 8 lines -->
+          <!-- Start Health Check -->
+          <div class="well">
+            <center><img src="/static/img/buttons/heroku-150.png" class="img-responsive"></center>
+            <h4>Heroku <small>Dyno Not Idle (Single)</small></h4>
+            <p>This monitor will trigger when a Dyno is in idle state.</p>
+          </div>
+          <!-- End Health Check 8 lines -->
+          <!-- Start Health Check -->
+          <div class="well">
+            <center><img src="/static/img/buttons/heroku-150.png" class="img-responsive"></center>
+            <h4>Heroku <small>Dyno Not Idle</small></h4>
+            <p>This monitor will will trigger when any Dyno is in an idle state.</p>
           </div>
           <!-- End Health Check 8 lines -->
         </div>

--- a/static/templates/monitors/heroku-dyno-not-idle-single.html
+++ b/static/templates/monitors/heroku-dyno-not-idle-single.html
@@ -1,0 +1,108 @@
+{% include 'base-header.html' %}
+
+
+<div class="container">
+  <div class="row">
+  <p></p>
+    <!-- sidebar -->
+    {% include 'sidebar.html' %}
+    <!-- content -->
+    <div class="col-md-8">
+      <div class="page-header">
+      {% if data['edit'] %}
+        <h1><i class="fa fa-eye-slash fa-1x"></i> Manage Monitor</h1>
+      {% else %}
+        <h1><i class="fa fa-eye-slash fa-1x"></i> Add Monitor</h1>
+      {% endif %}
+      </div>
+      {% if data['error'] %}
+      <p class="alert alert-danger">{{ data['msg'] }}</p>
+      {% elif data['msg'] and data['error'] == False %}
+      <p class="alert alert-success">{{ data['msg'] }}</p>
+      {% endif %}
+      {% if form.errors %}
+      {% for field, error in form.errors.items() %}
+      {% for msg in error %}
+      <p class="alert alert-danger">{{msg}}</p>
+      {% endfor %}
+      {% endfor %}
+      {% endif %}
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <div class="panel-title">
+            Heroku: Dyno Not Idle (Single Dyno)
+            </div>
+          </div>
+          <div class="panel-body">
+            <form action="{{ data['url'] }}" method="post" name="monitor" target="_self" class="form-horizontal" role="form">
+            {{ form.csrf_token }}
+
+            {% include 'monitors/base.html' %}
+            {% include 'monitors/timer.html' %}
+            {% include 'monitors/datacenter.html' %}
+            <hr>
+
+                <div class="form-group">
+                <label for="API Key" class="col-sm-4 control-label">API Key</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+              <span class="input-group-btn">
+                <button type="button" id="heroku-dyno-not-idle-single-apikey" class="btn btn-default" rel="popover" data-content="This field should contain your Heroku API Key, you can obtain your key from the Heroku Dashbaord. This shouldbe the non-base64 encoded key, we will encode this key later." title="Heroku API Key"><i class="fa fa-question"></i></button>
+              </span>
+              {% if data['edit'] %}
+              {{ form.apikey(class_="form-control", value=data['monitor']['data']['apikey']) }}
+              {% else %}
+              {{ form.apikey(class_="form-control", placeholder="Heroku API Key") }}
+              {% endif %}
+            </div>
+            </div>
+              </div>  
+
+                <div class="form-group">
+                <label for="App Name" class="col-sm-4 control-label">Application Name</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+              <span class="input-group-btn">
+                <button type="button" id="heroku-dyno-not-idle-single-appname" class="btn btn-default" rel="popover" data-content="This field should contain your Heroku Application Name. This is a required field for Heroku's API, if you wish to monitor multiple applications it will require additional monitors." title="Heroku Application Name"><i class="fa fa-question"></i></button>
+              </span>
+              {% if data['edit'] %}
+              {{ form.appname(class_="form-control", value=data['monitor']['data']['appname']) }}
+              {% else %}
+              {{ form.appname(class_="form-control", placeholder="Application Name") }}
+              {% endif %}
+            </div>
+            </div>
+              </div>  
+
+                <div class="form-group">
+                <label for="Dyno Name" class="col-sm-4 control-label">Dyno Name</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+              <span class="input-group-btn">
+                <button type="button" id="heroku-dyno-not-idle-single-dynoname" class="btn btn-default" rel="popover" data-content="This field should contain the name of the dyno you want to monitor." title="Heroku Dyno Name"><i class="fa fa-question"></i></button>
+              </span>
+              {% if data['edit'] %}
+              {{ form.dynoname(class_="form-control", value=data['monitor']['data']['dynoname']) }}
+              {% else %}
+              {{ form.dynoname(class_="form-control", placeholder="Dyno Name") }}
+              {% endif %}
+            </div>
+            </div>
+              </div>  
+            
+                <p></p>
+                <button type="submit" class="btn btn-primary btn-block">Submit</button>
+            </form>
+          </div>
+        </div>
+
+      <div class="panel-group" id="accordion">
+    {% include 'monitors/docs/url-details.html' %}
+
+      </div>
+
+    </div>
+  </div> <!-- row -->
+</div> <!-- container -->
+
+{% include 'dash-footer.html' %}

--- a/static/templates/monitors/heroku-dyno-not-idle-single.js
+++ b/static/templates/monitors/heroku-dyno-not-idle-single.js
@@ -1,0 +1,21 @@
+<script type="text/javascript">
+  $(document).ready(function() {
+    $("#heroku-dyno-not-idle-single-apikey").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+    $("#heroku-dyno-not-idle-single-appname").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+    $("#heroku-dyno-not-idle-single-dynoname").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+
+  });
+
+</script>

--- a/static/templates/monitors/heroku-dyno-not-idle.html
+++ b/static/templates/monitors/heroku-dyno-not-idle.html
@@ -1,0 +1,92 @@
+{% include 'base-header.html' %}
+
+
+<div class="container">
+  <div class="row">
+  <p></p>
+    <!-- sidebar -->
+    {% include 'sidebar.html' %}
+    <!-- content -->
+    <div class="col-md-8">
+      <div class="page-header">
+      {% if data['edit'] %}
+        <h1><i class="fa fa-eye-slash fa-1x"></i> Manage Monitor</h1>
+      {% else %}
+        <h1><i class="fa fa-eye-slash fa-1x"></i> Add Monitor</h1>
+      {% endif %}
+      </div>
+      {% if data['error'] %}
+      <p class="alert alert-danger">{{ data['msg'] }}</p>
+      {% elif data['msg'] and data['error'] == False %}
+      <p class="alert alert-success">{{ data['msg'] }}</p>
+      {% endif %}
+      {% if form.errors %}
+      {% for field, error in form.errors.items() %}
+      {% for msg in error %}
+      <p class="alert alert-danger">{{msg}}</p>
+      {% endfor %}
+      {% endfor %}
+      {% endif %}
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <div class="panel-title">
+            Heroku: Dyno Not Idle
+            </div>
+          </div>
+          <div class="panel-body">
+            <form action="{{ data['url'] }}" method="post" name="monitor" target="_self" class="form-horizontal" role="form">
+            {{ form.csrf_token }}
+
+            {% include 'monitors/base.html' %}
+            {% include 'monitors/timer.html' %}
+            {% include 'monitors/datacenter.html' %}
+            <hr>
+
+                <div class="form-group">
+                <label for="API Key" class="col-sm-4 control-label">API Key</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+              <span class="input-group-btn">
+                <button type="button" id="heroku-dyno-not-idle-apikey" class="btn btn-default" rel="popover" data-content="This field should contain your Heroku API Key, you can obtain your key from the Heroku Dashbaord. This shouldbe the non-base64 encoded key, we will encode this key later." title="Heroku API Key"><i class="fa fa-question"></i></button>
+              </span>
+              {% if data['edit'] %}
+              {{ form.apikey(class_="form-control", value=data['monitor']['data']['apikey']) }}
+              {% else %}
+              {{ form.apikey(class_="form-control", placeholder="Heroku API Key") }}
+              {% endif %}
+            </div>
+            </div>
+              </div>  
+
+                <div class="form-group">
+                <label for="App Name" class="col-sm-4 control-label">Application Name</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+              <span class="input-group-btn">
+                <button type="button" id="heroku-dyno-not-idle-appname" class="btn btn-default" rel="popover" data-content="This field should contain your Heroku Application Name. This is a required field for Heroku's API, if you wish to monitor multiple applications it will require additional monitors." title="Heroku Application Name"><i class="fa fa-question"></i></button>
+              </span>
+              {% if data['edit'] %}
+              {{ form.appname(class_="form-control", value=data['monitor']['data']['appname']) }}
+              {% else %}
+              {{ form.appname(class_="form-control", placeholder="Application Name") }}
+              {% endif %}
+            </div>
+            </div>
+              </div>  
+
+                <p></p>
+                <button type="submit" class="btn btn-primary btn-block">Submit</button>
+            </form>
+          </div>
+        </div>
+
+      <div class="panel-group" id="accordion">
+    {% include 'monitors/docs/url-details.html' %}
+
+      </div>
+
+    </div>
+  </div> <!-- row -->
+</div> <!-- container -->
+
+{% include 'dash-footer.html' %}

--- a/static/templates/monitors/heroku-dyno-not-idle.js
+++ b/static/templates/monitors/heroku-dyno-not-idle.js
@@ -1,0 +1,21 @@
+<script type="text/javascript">
+  $(document).ready(function() {
+    $("#heroku-dyno-not-idle-apikey").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+    $("#heroku-dyno-not-idle-appname").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+    $("#heroku-dyno-not-idle-dynoname").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+
+  });
+
+</script>

--- a/static/templates/monitors/heroku-dyno-status-single.html
+++ b/static/templates/monitors/heroku-dyno-status-single.html
@@ -1,0 +1,108 @@
+{% include 'base-header.html' %}
+
+
+<div class="container">
+  <div class="row">
+  <p></p>
+    <!-- sidebar -->
+    {% include 'sidebar.html' %}
+    <!-- content -->
+    <div class="col-md-8">
+      <div class="page-header">
+      {% if data['edit'] %}
+        <h1><i class="fa fa-eye-slash fa-1x"></i> Manage Monitor</h1>
+      {% else %}
+        <h1><i class="fa fa-eye-slash fa-1x"></i> Add Monitor</h1>
+      {% endif %}
+      </div>
+      {% if data['error'] %}
+      <p class="alert alert-danger">{{ data['msg'] }}</p>
+      {% elif data['msg'] and data['error'] == False %}
+      <p class="alert alert-success">{{ data['msg'] }}</p>
+      {% endif %}
+      {% if form.errors %}
+      {% for field, error in form.errors.items() %}
+      {% for msg in error %}
+      <p class="alert alert-danger">{{msg}}</p>
+      {% endfor %}
+      {% endfor %}
+      {% endif %}
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <div class="panel-title">
+            Heroku: Dyno Status (Single Dyno)
+            </div>
+          </div>
+          <div class="panel-body">
+            <form action="{{ data['url'] }}" method="post" name="monitor" target="_self" class="form-horizontal" role="form">
+            {{ form.csrf_token }}
+
+            {% include 'monitors/base.html' %}
+            {% include 'monitors/timer.html' %}
+            {% include 'monitors/datacenter.html' %}
+            <hr>
+
+                <div class="form-group">
+                <label for="API Key" class="col-sm-4 control-label">API Key</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+              <span class="input-group-btn">
+                <button type="button" id="heroku-dyno-status-single-apikey" class="btn btn-default" rel="popover" data-content="This field should contain your Heroku API Key, you can obtain your key from the Heroku Dashbaord. This shouldbe the non-base64 encoded key, we will encode this key later." title="Heroku API Key"><i class="fa fa-question"></i></button>
+              </span>
+              {% if data['edit'] %}
+              {{ form.apikey(class_="form-control", value=data['monitor']['data']['apikey']) }}
+              {% else %}
+              {{ form.apikey(class_="form-control", placeholder="Heroku API Key") }}
+              {% endif %}
+            </div>
+            </div>
+              </div>  
+
+                <div class="form-group">
+                <label for="App Name" class="col-sm-4 control-label">Application Name</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+              <span class="input-group-btn">
+                <button type="button" id="heroku-dyno-status-single-appname" class="btn btn-default" rel="popover" data-content="This field should contain your Heroku Application Name. This is a required field for Heroku's API, if you wish to monitor multiple applications it will require additional monitors." title="Heroku Application Name"><i class="fa fa-question"></i></button>
+              </span>
+              {% if data['edit'] %}
+              {{ form.appname(class_="form-control", value=data['monitor']['data']['appname']) }}
+              {% else %}
+              {{ form.appname(class_="form-control", placeholder="Application Name") }}
+              {% endif %}
+            </div>
+            </div>
+              </div>  
+
+                <div class="form-group">
+                <label for="Dyno Name" class="col-sm-4 control-label">Dyno Name</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+              <span class="input-group-btn">
+                <button type="button" id="heroku-dyno-status-single-dynoname" class="btn btn-default" rel="popover" data-content="This field should contain the name of the dyno you want to monitor." title="Heroku Dyno Name"><i class="fa fa-question"></i></button>
+              </span>
+              {% if data['edit'] %}
+              {{ form.dynoname(class_="form-control", value=data['monitor']['data']['dynoname']) }}
+              {% else %}
+              {{ form.dynoname(class_="form-control", placeholder="Dyno Name") }}
+              {% endif %}
+            </div>
+            </div>
+              </div>  
+            
+                <p></p>
+                <button type="submit" class="btn btn-primary btn-block">Submit</button>
+            </form>
+          </div>
+        </div>
+
+      <div class="panel-group" id="accordion">
+    {% include 'monitors/docs/url-details.html' %}
+
+      </div>
+
+    </div>
+  </div> <!-- row -->
+</div> <!-- container -->
+
+{% include 'dash-footer.html' %}

--- a/static/templates/monitors/heroku-dyno-status-single.js
+++ b/static/templates/monitors/heroku-dyno-status-single.js
@@ -1,0 +1,21 @@
+<script type="text/javascript">
+  $(document).ready(function() {
+    $("#heroku-dyno-status-single-apikey").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+    $("#heroku-dyno-status-single-appname").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+    $("#heroku-dyno-status-single-dynoname").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+
+  });
+
+</script>

--- a/static/templates/monitors/heroku-dyno-status.html
+++ b/static/templates/monitors/heroku-dyno-status.html
@@ -1,0 +1,92 @@
+{% include 'base-header.html' %}
+
+
+<div class="container">
+  <div class="row">
+  <p></p>
+    <!-- sidebar -->
+    {% include 'sidebar.html' %}
+    <!-- content -->
+    <div class="col-md-8">
+      <div class="page-header">
+      {% if data['edit'] %}
+        <h1><i class="fa fa-eye-slash fa-1x"></i> Manage Monitor</h1>
+      {% else %}
+        <h1><i class="fa fa-eye-slash fa-1x"></i> Add Monitor</h1>
+      {% endif %}
+      </div>
+      {% if data['error'] %}
+      <p class="alert alert-danger">{{ data['msg'] }}</p>
+      {% elif data['msg'] and data['error'] == False %}
+      <p class="alert alert-success">{{ data['msg'] }}</p>
+      {% endif %}
+      {% if form.errors %}
+      {% for field, error in form.errors.items() %}
+      {% for msg in error %}
+      <p class="alert alert-danger">{{msg}}</p>
+      {% endfor %}
+      {% endfor %}
+      {% endif %}
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <div class="panel-title">
+            Heroku: Dyno Status
+            </div>
+          </div>
+          <div class="panel-body">
+            <form action="{{ data['url'] }}" method="post" name="monitor" target="_self" class="form-horizontal" role="form">
+            {{ form.csrf_token }}
+
+            {% include 'monitors/base.html' %}
+            {% include 'monitors/timer.html' %}
+            {% include 'monitors/datacenter.html' %}
+            <hr>
+
+                <div class="form-group">
+                <label for="API Key" class="col-sm-4 control-label">API Key</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+              <span class="input-group-btn">
+                <button type="button" id="heroku-dyno-status-apikey" class="btn btn-default" rel="popover" data-content="This field should contain your Heroku API Key, you can obtain your key from the Heroku Dashbaord. This shouldbe the non-base64 encoded key, we will encode this key later." title="Heroku API Key"><i class="fa fa-question"></i></button>
+              </span>
+              {% if data['edit'] %}
+              {{ form.apikey(class_="form-control", value=data['monitor']['data']['apikey']) }}
+              {% else %}
+              {{ form.apikey(class_="form-control", placeholder="Heroku API Key") }}
+              {% endif %}
+            </div>
+            </div>
+              </div>  
+
+                <div class="form-group">
+                <label for="App Name" class="col-sm-4 control-label">Application Name</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+              <span class="input-group-btn">
+                <button type="button" id="heroku-dyno-status-appname" class="btn btn-default" rel="popover" data-content="This field should contain your Heroku Application Name. This is a required field for Heroku's API, if you wish to monitor multiple applications it will require additional monitors." title="Heroku Application Name"><i class="fa fa-question"></i></button>
+              </span>
+              {% if data['edit'] %}
+              {{ form.appname(class_="form-control", value=data['monitor']['data']['appname']) }}
+              {% else %}
+              {{ form.appname(class_="form-control", placeholder="Application Name") }}
+              {% endif %}
+            </div>
+            </div>
+              </div>  
+
+                <p></p>
+                <button type="submit" class="btn btn-primary btn-block">Submit</button>
+            </form>
+          </div>
+        </div>
+
+      <div class="panel-group" id="accordion">
+    {% include 'monitors/docs/url-details.html' %}
+
+      </div>
+
+    </div>
+  </div> <!-- row -->
+</div> <!-- container -->
+
+{% include 'dash-footer.html' %}

--- a/static/templates/monitors/heroku-dyno-status.js
+++ b/static/templates/monitors/heroku-dyno-status.js
@@ -1,0 +1,21 @@
+<script type="text/javascript">
+  $(document).ready(function() {
+    $("#heroku-dyno-status-apikey").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+    $("#heroku-dyno-status-appname").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+    $("#heroku-dyno-status-dynoname").popover({
+        placement : 'auto bottom',
+        container: 'body',
+        trigger: 'click focus',
+    });
+
+  });
+
+</script>

--- a/static/templates/monitors/index.html
+++ b/static/templates/monitors/index.html
@@ -38,6 +38,22 @@
             <a href="/dashboard/monitors/ping" class="btn btn-primary btn-md btn-block" role="button">Create</a>
           </div>
           <!-- End Health Check 8 lines -->
+          <!-- Start Health Check -->
+          <div class="well">
+            <center><img src="/static/img/buttons/heroku-150.png" class="img-responsive"></center>
+            <h4>Heroku <small>Dyno Status (Single)</small></h4>
+            <p>This monitor will watch the status of a specific Dyno.</p>
+            <a href="/dashboard/monitors/heroku-dyno-status-single" class="btn btn-primary btn-md btn-block" role="button">Create</a>
+          </div>
+          <!-- End Health Check 8 lines -->
+          <!-- Start Health Check -->
+          <div class="well">
+            <center><img src="/static/img/buttons/heroku-150.png" class="img-responsive"></center>
+            <h4>Heroku <small>Dyno Status</small></h4>
+            <p>This monitor will watch the status of all Dynos.</p>
+            <a href="/dashboard/monitors/heroku-dyno-status" class="btn btn-primary btn-md btn-block" role="button">Create</a>
+          </div>
+          <!-- End Health Check 8 lines -->
         </div>
         <div class="col-md-6">
           <!-- Start Health Check -->
@@ -71,6 +87,22 @@
             <h4>Logentries Alerts <small>Webhooks</small></h4>
             <p>Use Logentries Alerts and Tags to trigger CloudRoutes reactions.</p>
             <a href="/dashboard/monitors/logentries-webhook" class="btn btn-primary btn-md btn-block" role="button">Create</a>
+          </div>
+          <!-- End Health Check 8 lines -->
+          <!-- Start Health Check -->
+          <div class="well">
+            <center><img src="/static/img/buttons/heroku-150.png" class="img-responsive"></center>
+            <h4>Heroku <small>Dyno Not Idle (Single)</small></h4>
+            <p>This monitor will trigger when a Dyno is in idle state.</p>
+            <a href="/dashboard/monitors/heroku-dyno-not-idle-single" class="btn btn-primary btn-md btn-block" role="button">Create</a>
+          </div>
+          <!-- End Health Check 8 lines -->
+          <!-- Start Health Check -->
+          <div class="well">
+            <center><img src="/static/img/buttons/heroku-150.png" class="img-responsive"></center>
+            <h4>Heroku <small>Dyno Not Idle</small></h4>
+            <p>This monitor will will trigger when any Dyno is in an idle state.</p>
+            <a href="/dashboard/monitors/heroku-dyno-not-idle" class="btn btn-primary btn-md btn-block" role="button">Create</a>
           </div>
           <!-- End Health Check 8 lines -->
         </div>


### PR DESCRIPTION
Adding in status checks for heroku idle and heroku dyno status up/idle. Also added in the ability for the worker.py to not mark a monitor as failed if the return is None. This is to reduce the likely hood of reacting poorly to bad situations.
