### PR TITLE
Added new url config and error handling

### DIFF
--- a/src/crbridge/config/config.yml.example
+++ b/src/crbridge/config/config.yml.example
@@ -29,3 +29,4 @@ history_retention: 18000
 ## MailChimp
 mailchimp_api_key: "update_me!"
 mailchimp_list_id: "update_me!"
+mailchimp_api_url: "https://us2.api.mailchimp.com/2.0"


### PR DESCRIPTION
When testing this I found that each mailchimp API key is attached to a specific datacenter/url. So I made the URL a configurable item. I also added a `sys.exit(1)` if all of the emails failed to add.

Another minor change is in the header section of the script. Experimenting with a better header template.
