### PR TITLE
Actioner performance boost

### DIFF
--- a/src/cram/worker.py
+++ b/src/cram/worker.py
@@ -9,10 +9,9 @@
 # send a failure json message to the sink, on success it sends a
 # successful message.
 # ------------------------------------------------------------------
-# Version: Alpha.20140424
-# Original Author: Benjamin J. Cane - madflojo@cloudrout.es
-# Contributors:
-# - your name here
+# Original Author: Benjamin J. Cane - @madflojo
+# Maintainers:
+# - Benjamin Cane - @madflojo
 #####################################################################
 
 
@@ -116,6 +115,7 @@ while True:
         syslog.syslog(syslog.LOG_INFO, line)
         jdata['check'] = {'status': 'healthy',
                           'method': 'automatic'}
+        jdata['time_tracking']['worker'] = time.time()
         # Send success to sink
         ztext = json.dumps(jdata)
     elif result is None:

--- a/src/crbridge/bridge.py
+++ b/src/crbridge/bridge.py
@@ -9,10 +9,9 @@
 # This will gather queue tasks from rethinkdb and create/delete
 # the appropriate monitor in cram.
 # ------------------------------------------------------------------
-# Version: Alpha.20140306
-# Original Author: Benjamin J. Cane - madflojo@cloudrout.es
-# Contributors:
-# - your name here
+# Original Author: Benjamin J. Cane - @madflojo
+# Maintainers:
+# - Benjamin Cane - @madflojo
 #####################################################################
 
 

--- a/src/crbridge/broker.py
+++ b/src/crbridge/broker.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python
+#####################################################################
+# Cloud Routes Bridge: Broker
+# ------------------------------------------------------------------
+# Description:
+# ------------------------------------------------------------------
+# This is a message broker for the actioner.
+# This process will get messages from the various cram processes
+# and send them to the actioner worker processes via zMQ.
+# ------------------------------------------------------------------
+# Original Author: Benjamin J. Cane - @madflojo
+# Maintainers:
+# - Benjamin Cane - @madflojo
+#####################################################################
+
+
+# Imports
+# ------------------------------------------------------------------
+
+import sys
+import zmq
+import time
+import yaml
+import signal
+import syslog
+
+# Load Configuration
+# ------------------------------------------------------------------
+
+if len(sys.argv) != 2:
+    print("Hey, thats not how you launch this...")
+    print("%s <config file>") % sys.argv[0]
+    sys.exit(1)
+
+# Open Config File and Parse Config Data
+configfile = sys.argv[1]
+cfh = open(configfile, "r")
+config = yaml.safe_load(cfh)
+cfh.close()
+
+
+# Make Connections
+# ------------------------------------------------------------------
+
+# Open Syslog
+syslog.openlog(logoption=syslog.LOG_PID, facility=syslog.LOG_LOCAL0)
+
+# Start ZeroMQ listener for control
+context = zmq.Context()
+zrecv = context.socket(zmq.PULL)
+bindaddress = "tcp://%s:%d" % (config['sink_ip'],
+                               config['sink_port'])
+zrecv.bind(bindaddress)
+line = "Attempting to bind to %s" % bindaddress
+syslog.syslog(syslog.LOG_INFO, line)
+
+# Start ZeroMQ listener for workers
+context2 = zmq.Context()
+zsend = context2.socket(zmq.PUSH)
+bindaddress = "tcp://%s:%d" % (config['sink_ip'],
+                               config['sink_worker_port'])
+zsend.bind(bindaddress)
+line = "Attempting to bind to %s" % bindaddress
+syslog.syslog(syslog.LOG_INFO, line)
+
+
+# Handle Kill Signals Cleanly
+# ------------------------------------------------------------------
+
+def killhandle(signum, frame):
+    ''' This will close connections cleanly '''
+    line = "SIGTERM detected, shutting down"
+    syslog.syslog(syslog.LOG_INFO, line)
+    syslog.closelog()
+    zsend.close()
+    zrecv.close()
+    sys.exit(0)
+
+signal.signal(signal.SIGTERM, killhandle)
+
+
+# Run For Loop
+# ------------------------------------------------------------------
+
+# Let the workers get started
+time.sleep(20)
+
+# Start an infinante loop that checks every 2 minutes
+while True:
+    # Get list of members to check from queue
+    msg = zrecv.recv()
+    line = "Got the following message and sent it off %s" % msg
+    syslog.syslog(syslog.LOG_DEBUG, line)
+    zsend.send(msg)
+
+    # The following should be disabled unless it is times of distress
+    #import json
+    #jdata = json.loads(msg)
+    #line = "Sent health check %s to workers" % jdata['cid']
+    #syslog.syslog(syslog.LOG_DEBUG, line)

--- a/src/crbridge/config/config.yml.example
+++ b/src/crbridge/config/config.yml.example
@@ -16,6 +16,9 @@ rethink_db: "crdb"
 ## Sink Config
 sink_ip: 127.0.0.1
 sink_port: "update_me!"
+sink_worker_port: "update_me!"
+## Maximum time for monitor execution
+max_monitor_time: 600
 default_actions:
   - logit-monitor
   - logit-events


### PR DESCRIPTION
The actioner has had some issues lately with performance, I believe the root cause may be due to it's single threaded nature. So with this I have added a broker to act as the "sink" and made the `actioner.py` process able to launch multiple instances.

I also added a time check on the actioner to make sure that monitors don't exceed a configurable max time, if they do an alert is raised however this may be extended in the future to not action the monitor. Also fixed a missing time_tracking value on healthy monitors from the `cram/worker.py` process.
