### PR TITLE
Add Procfile to run runbook processes

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,7 @@
+web: python src/web/web.py instance/web.cfg.default
+monitors_control: python src/monitors/control.py src/monitors/config/control.yml.5min.default
+monitors_broker: python src/monitors/broker.py src/monitors/config/main.yml.default
+monitors_worker: python src/monitors/worker.py src/monitors/config/main.yml.default
+bridge: python src/bridge/bridge.py src/bridge/config/config.yml.default
+actions_broker: python src/actions/broker.py src/bridge/config/config.yml.default
+actions_actioner: python src/actions/actioner.py src/actions/config/config.yml.default


### PR DESCRIPTION
Makes it really easy to run and kill all processes required for runbook (doesn't include rethinkdb and redis for now intentionally)
- Developer needs to install either foreman / honcho / one of other procfile runners and simply call
  `honcho -f Procfile.dev start`.
- To terminate all processes, `Ctrl + C`
