### PR TITLE
Media query so text fits in call-to-action button

### DIFF
--- a/src/web/static/css/home.css
+++ b/src/web/static/css/home.css
@@ -74,8 +74,8 @@ body {
 
 .hero-section .btn.hero-call-to-action {
   color: #fff;
-  font-size: 280% !important;
-  padding: 20px 80px !important;
+  font-size: 200%;
+  padding: 10px;
   display: block;
   max-width: 500px;
   margin: 40px auto;
@@ -84,6 +84,13 @@ body {
   -webkit-border-radius: 10px;
 	-moz-border-radius: 10px;
 	-o-border-radius: 10px;
+}
+
+@media screen and (min-width: 500px) {
+  .hero-section .btn.hero-call-to-action {
+    font-size: 280%;
+    padding: 20px 80px;
+  }
 }
 
 .btn.btn-action {


### PR DESCRIPTION
Fix is for this bug report: https://assembly.com/runbook/bounties/160

Added a media query to reduce the text/side padding on the call-to-action button on smaller (mobile) screens. Removed !important flags, as the specificity seems to be high enough that they aren't needed.

Previous screenshot:
![screen shot 2014-12-18 at 9 35 22 am](https://cloud.githubusercontent.com/assets/1382445/5492768/3810ae1c-8699-11e4-85ed-3d58abd87e2e.png)

After the media query is added:
![screen shot 2014-12-18 at 9 34 36 am](https://cloud.githubusercontent.com/assets/1382445/5492755/1fe74b20-8699-11e4-9eaa-ed05083d9f48.png)
