### PR TITLE
Monitor and Reaction Encryption

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ web:
   build: src/web/
   volumes:
     - ./src/web:/code:ro
+    - ./src/web/instance:/config:ro
   ports:
     - "80:8000"
   links:

--- a/src/actions/actions/chstatus/__init__.py
+++ b/src/actions/actions/chstatus/__init__.py
@@ -54,7 +54,7 @@ def chStatus(cid, status, rdb, r_server, logger):
 
     # Then set redis cache
     try:
-        r_server.hset("monitor:" + cid, 'status', status)
+        r_server.set("monitor:" + cid + ':status', status)
         success = True
     except:
         line = "chstatus: Redis is inaccessible cannot change status for %s" % cid
@@ -89,7 +89,7 @@ def resetFailcount(cid, rdb, r_server, logger):
 
     # Then set redis cache
     try:
-        r_server.hset("monitor:" + cid, 'failcount', failcount)
+        r_server.set("monitor:" + cid + ':failcount', failcount)
         success = True
     except:
         line = "chstatus: Redis is inaccessible cannot change failcount for %s" % cid
@@ -124,7 +124,7 @@ def incFailcount(cid, failcount, rdb, r_server, logger):
 
     # Then set redis cache
     try:
-        r_server.hset("monitor:" + cid, 'failcount', failcount)
+        r_server.set("monitor:" + cid + ':failcount', failcount)
         success = True
     except:
         line = "chstatus: Redis is inaccessible cannot change failcount for %s" % cid

--- a/src/actions/actions/update-lastrun/__init__.py
+++ b/src/actions/actions/update-lastrun/__init__.py
@@ -49,7 +49,7 @@ def chlastrun(rid, rdb, r_server, logger):
 
     # Then set redis cache
     try:
-        r_server.hset("reaction:" + rid, 'lastrun', lastrun)
+        r_server.set("reaction:" + rid + ':lastrun', lastrun)
         line = "update-lastrun: Redis lastrun for %s is now set to: %r" % (
             rid, lastrun)
         logger.info(line)

--- a/src/actions/config/config.yml
+++ b/src/actions/config/config.yml
@@ -38,3 +38,5 @@ mandrill_api_url: "https://mandrillapp.com/api/1.0/"
 mandrill_api_key: "update_me!"
 ## Logging
 use_syslog: False
+## Cryptography
+crypto_key: "IguaOorhzw8VRotv7fznbQN5MtlI6X-AFUQ8K90cNZ4="

--- a/src/actions/requirements.txt
+++ b/src/actions/requirements.txt
@@ -11,3 +11,4 @@ mandrill
 pyOpenSSL
 ndg-httpsclient
 pyasn1
+cryptography

--- a/src/bridge/Dockerfile
+++ b/src/bridge/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update --fix-missing
 RUN apt-get upgrade -y
 
 # Install python
-RUN apt-get install -y python python-dev python-pip python-virtualenv wget unzip
+RUN apt-get install -y python python-dev python-pip python-virtualenv wget unzip libssl-dev libffi-dev
 RUN rm -rf /var/lib/apt/lists/*
 
 

--- a/src/bridge/config/config.yml
+++ b/src/bridge/config/config.yml
@@ -27,4 +27,4 @@ mailchimp_list_id: "update_me"
 mailchimp_api_url: "update_me"
 ## Logging
 use_syslog: False
-
+crypto_key: "IguaOorhzw8VRotv7fznbQN5MtlI6X-AFUQ8K90cNZ4="

--- a/src/bridge/requirements.txt
+++ b/src/bridge/requirements.txt
@@ -8,3 +8,4 @@ rethinkdb==1.13.0-3
 Werkzeug==0.9.6
 twilio>=3.6.0
 guppy==0.1.10
+cryptography

--- a/src/monitors/config/worker.yml
+++ b/src/monitors/config/worker.yml
@@ -11,3 +11,5 @@ stathat_ez_key: update_me!
 envname: "[Self Hosted]"
 ## Logging
 use_syslog: False
+## Cryptography
+crypto_key: "IguaOorhzw8VRotv7fznbQN5MtlI6X-AFUQ8K90cNZ4="

--- a/src/monitors/control.py
+++ b/src/monitors/control.py
@@ -90,29 +90,10 @@ while True:
     count = 0
     # Get list of members to check from queue
     for check in r_server.smembers(config['queue']):
-        checkdata = {'cid': check, 'data': {}}
-        # Non-Data Keys
         monkey = "monitor:" + check
-        for key in r_server.hkeys(monkey):
-            value = r_server.hget(monkey, key)
-            if value == "slist":
-                checkdata[key] = []
-                listkey = monkey + ":" + key
-                for entry in r_server.smembers(listkey):
-                    checkdata[key].append(entry)
-            else:
-                checkdata[key] = value
-        # Data Keys
-        monkey = "monitor:" + check + ":data"
-        for key in r_server.hkeys(monkey):
-            value = r_server.hget(monkey, key)
-            if value == "slist":
-                checkdata['data'][key] = []
-                listkey = monkey + ":" + key
-                for entry in r_server.smembers(listkey):
-                    checkdata['data'][key].append(entry)
-            else:
-                checkdata['data'][key] = value
+        data = r_server.get(monkey)
+        checkdata = json.loads(data)
+        checkdata['cid'] = check
         checkdata['time_tracking'] = {'control': time.time(),
                                       'ez_key': config['stathat_key'],
                                       'env': str(config['envname'])}

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update --fix-missing
 RUN apt-get upgrade -y
 
 # Install python
-RUN apt-get install -y python python-dev python-pip python-virtualenv wget unzip
+RUN apt-get install -y python python-dev python-pip python-virtualenv wget unzip build-essential libssl-dev libffi-dev
 RUN rm -rf /var/lib/apt/lists/*
 
 

--- a/src/web/instance/web.cfg
+++ b/src/web/instance/web.cfg
@@ -3,6 +3,8 @@ SECRET_KEY = "update_me!"
 SECURITY_PASSWORD_SALT = "update_me!"
 PASSWORD_SALT = "update_me!"
 SALT = "update_me!"
+CRYPTO_KEY = "IguaOorhzw8VRotv7fznbQN5MtlI6X-AFUQ8K90cNZ4="
+CRYPTO_ENABLED = False
 
 ## Service Info
 BIND_IP = "0.0.0.0"

--- a/src/web/instance/web.cfg
+++ b/src/web/instance/web.cfg
@@ -3,7 +3,7 @@ SECRET_KEY = "update_me!"
 SECURITY_PASSWORD_SALT = "update_me!"
 PASSWORD_SALT = "update_me!"
 SALT = "update_me!"
-CRYPTO_KEY = "IguaOorhzw8VRotv7fznbQN5MtlI6X-AFUQ8K90cNZ4="
+CRYPTO_KEY = "update_me!"
 CRYPTO_ENABLED = False
 
 ## Service Info

--- a/src/web/member/views.py
+++ b/src/web/member/views.py
@@ -58,6 +58,7 @@ def dashboard_page():
         app.config['SECRET_KEY'], app.config['COOKIE_TIMEOUT'], request.cookies)
     if verify:
         user = User()
+        user.config = app.config
         user.get('uid', verify, g.rdb_conn)
         data = startData(user)
         data['active'] = 'dashboard'
@@ -120,6 +121,7 @@ def modsub_page():
         app.config['SECRET_KEY'], app.config['COOKIE_TIMEOUT'], request.cookies)
     if verify:
         user = User()
+        user.config = app.config
         user.get('uid', verify, g.rdb_conn)
         data = startData(user)
         data['active'] = 'dashboard'

--- a/src/web/monitor/views.py
+++ b/src/web/monitor/views.py
@@ -448,9 +448,8 @@ def checkapi_page(atype, cid, check_key, action):
         webapi = __import__(
             "monitorapis." + atype, globals(), locals(), ['webCheck'], -1)
         replydata = webapi.webCheck(request, monitor, urldata, g.rdb_conn)
-        print("Reply Data: " + replydata)
     except Exception as e:
-        print("/api/%s - webCheck action failed - %s") % (atype, e.message)
+        app.logger.error("/api/%s - webCheck action failed - %s" % (atype, e.message))
         replydata = {
             'headers': {'Content-type': 'application/json'},
             'data': "{ 'results' : 'fatal error'  }"

--- a/src/web/requirements.txt
+++ b/src/web/requirements.txt
@@ -14,3 +14,4 @@ requests
 rethinkdb
 stripe
 wsgiref
+cryptography

--- a/src/web/user/views.py
+++ b/src/web/user/views.py
@@ -190,6 +190,7 @@ def confirm_email(token):
         app.config['SECRET_KEY'], app.config['COOKIE_TIMEOUT'], request.cookies)
     if verify:
         user = User()
+        user.config = app.config
         user.get('uid', verify, g.rdb_conn)
         if user.confirmed:
             flash('Account already confirmed. Thank you.', 'success')


### PR DESCRIPTION
fix #323 

One reason we don't have monitors that accept a username or password is the last of db encryption. This PR fixes that.

This PR adds the ability to turn on and off encryption for monitor and reaction data within RethinkDB, Redis and over ZeroMQ. To do this I did have to migrate the design of bridge and control processes and how they pull data from redis. Before Monitor and Reaction data was stored as a Hash set in redis, now it's simply a JSON string.

I also had to add specific keys for `failcount` and `lastrun`.

Overall however, this gives users the ability to enable encryption, which is a big plus.

Also encryption can be enabled on an existing system without problems, however a purge_redis and rebuild_redis needs to be executed.